### PR TITLE
[BUGFIX] node http may receive data in partials

### DIFF
--- a/freesound.js
+++ b/freesound.js
@@ -67,13 +67,17 @@
                     headers: {'Authorization': authHeader}
                 };
                 var req = http.request(options,function(res){
+                	var result = '';
                     res.setEncoding('utf8');            
                     res.on('data', function (data){ 
-                        if([200,201,202].indexOf(res.statusCode)>=0)
+                        result += data;
+                    });
+                    res.on('end', function() {
+                    	if([200,201,202].indexOf(res.statusCode)>=0)
                             success(wrapper?wrapper(data):data);
                         else   
                             error(data);
-                    });                    
+                    })
                 });                
                 req.on('error', error).end();
             }

--- a/freesound.js
+++ b/freesound.js
@@ -77,7 +77,7 @@
                             success(wrapper?wrapper(data):data);
                         else   
                             error(data);
-                    })
+                    });
                 });                
                 req.on('error', error).end();
             }


### PR DESCRIPTION
When using the library in cordova, the data is received in partials, which cannot be processed.

So I fixed it by concatenating the data before sending the result to the function that asked for the data.

See also the example at [node documentation](https://nodejs.org/api/http.html#http_http_request_options_callback)