### PR TITLE
Return full xhr contents on error

### DIFF
--- a/freesound.js
+++ b/freesound.js
@@ -92,7 +92,7 @@
                         if(success) success(wrapper?wrapper(data):data);
                     }
                     else if (xhr.readyState === 4 && xhr.status !== 200){
-                        if(error) error(xhr.statusText);
+                        if(error) error(xhr);
                     }
                 };
                 xhr.open(method, uri);


### PR DESCRIPTION
This change allows to get more information when an error occurs. In this way error messages returned by Freesound can be read.